### PR TITLE
Use obstore not fsspec in VirtualChunkContainer

### DIFF
--- a/src/intake_virtual_icechunk/cat.py
+++ b/src/intake_virtual_icechunk/cat.py
@@ -12,8 +12,8 @@ from urllib.parse import urlparse
 
 import obstore
 import pydantic
-from pydantic import ConfigDict
 from obstore.store import from_url as _obs_from_url
+from pydantic import ConfigDict
 
 from intake_virtual_icechunk.source._containers import VirtualChunkContainerModel
 from intake_virtual_icechunk.utils import _filter_config_args, _path_to_url
@@ -86,7 +86,9 @@ class VirtualIcechunkCatalogModel(pydantic.BaseModel):
             filename = p.name
         else:
             directory_url, filename = json_file.rsplit("/", 1)
-        obs_store = _obs_from_url(directory_url, config=_filter_config_args(storage_options))
+        obs_store = _obs_from_url(
+            directory_url, config=_filter_config_args(storage_options)
+        )
         content = obstore.get(obs_store, filename).bytes()
         return cls.model_validate(json.loads(bytes(content)))
 

--- a/src/intake_virtual_icechunk/cat.py
+++ b/src/intake_virtual_icechunk/cat.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 
 import datetime
 import json
-import os
 import typing
+from typing import TYPE_CHECKING
 
 import fsspec
+import obstore
 import pydantic
 from pydantic import ConfigDict
 
 from intake_virtual_icechunk.source._containers import VirtualChunkContainerModel
+
+if TYPE_CHECKING:
+    from obstore.store import ObjectStore
 
 
 class VirtualIcechunkCatalogModel(pydantic.BaseModel):
@@ -79,9 +83,8 @@ class VirtualIcechunkCatalogModel(pydantic.BaseModel):
         self,
         name: str,
         *,
-        directory: str | None = None,
+        store: ObjectStore,
         json_dump_kwargs: dict | None = None,
-        storage_options: dict[str, typing.Any] | None = None,
     ) -> None:
         """
         Save the catalog model to a JSON sidecar file.
@@ -90,36 +93,24 @@ class VirtualIcechunkCatalogModel(pydantic.BaseModel):
         ----------
         name : str
             Stem of the output file. If it ends with '.json' it will be stripped
-            and re-!dded to ensuer we get a single `.json` ext, no matter what.
-        directory : str, optional
-            Directory or cloud storage bucket to write the file to.
-            Defaults to the current working directory.
+            and re-added to ensure we get a single `.json` ext, no matter what.
+        store : ObjectStore
+            An obstore store (e.g. ``S3Store``, ``LocalStore``) pointing at the
+            directory into which the sidecar should be written.
         json_dump_kwargs : dict, optional
             Additional keyword arguments forwarded to :func:`json.dump`.
-        storage_options : dict, optional
-            fsspec parameters for *writing* the JSON file (e.g. S3 credentials
-            for the sidecar file itself, independent of the catalog's own
-            ``storage_options``).
         """
-        if directory is None:
-            directory = os.getcwd()
-
         name = name.removesuffix(".json")
-
-        storage_options = storage_options or {}
-        mapper = fsspec.get_mapper(directory, **storage_options)
-        fs = mapper.fs
-        json_file_name = fs.unstrip_protocol(f"{mapper.root}/{name}.json")
 
         data = self.model_dump().copy()
         data["id"] = name
         data["last_updated"] = datetime.datetime.now().isoformat()
 
-        with fs.open(json_file_name, "w") as outfile:
-            json_kwargs: dict[str, typing.Any] = {"indent": 2, "default": str}
-            json_kwargs |= json_dump_kwargs or {}
-            json.dump(data, outfile, **json_kwargs)
+        json_kwargs: dict[str, typing.Any] = {"indent": 2, "default": str}
+        json_kwargs |= json_dump_kwargs or {}
+        content = json.dumps(data, **json_kwargs).encode()
 
-        print(
-            f"Successfully wrote Virtual Icechunk catalog json file to: {json_file_name}"
-        )
+        path = f"{name}.json"
+        obstore.put(store, path, content)
+
+        print(f"Successfully wrote Virtual Icechunk catalog json file to: {path}")

--- a/src/intake_virtual_icechunk/cat.py
+++ b/src/intake_virtual_icechunk/cat.py
@@ -6,14 +6,17 @@ from __future__ import annotations
 import datetime
 import json
 import typing
+from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
-import fsspec
 import obstore
 import pydantic
 from pydantic import ConfigDict
+from obstore.store import from_url as _obs_from_url
 
 from intake_virtual_icechunk.source._containers import VirtualChunkContainerModel
+from intake_virtual_icechunk.utils import _filter_config_args, _path_to_url
 
 if TYPE_CHECKING:
     from obstore.store import ObjectStore
@@ -69,15 +72,23 @@ class VirtualIcechunkCatalogModel(pydantic.BaseModel):
         json_file : str
             Path or URL to the JSON sidecar file.
         storage_options : dict, optional
-            fsspec parameters for reading the JSON file itself (e.g. S3
+            obstore config kwargs for reading the JSON file itself (e.g. S3
             credentials).  These are independent of the catalog's own
             ``storage_options``, which are stored inside the JSON and used to
             open the Icechunk store.
         """
         storage_options = storage_options or {}
-        with fsspec.open(json_file, **storage_options) as fobj:
-            data = json.loads(fobj.read())
-        return cls.model_validate(data)
+        parsed = urlparse(json_file)
+        scheme = parsed.scheme
+        if scheme in ("", "file") or (len(scheme) == 1 and scheme.isalpha()):
+            p = Path(parsed.path if scheme == "file" else json_file)
+            directory_url = _path_to_url(str(p.parent))
+            filename = p.name
+        else:
+            directory_url, filename = json_file.rsplit("/", 1)
+        obs_store = _obs_from_url(directory_url, config=_filter_config_args(storage_options))
+        content = obstore.get(obs_store, filename).bytes()
+        return cls.model_validate(json.loads(bytes(content)))
 
     def save(
         self,

--- a/src/intake_virtual_icechunk/core.py
+++ b/src/intake_virtual_icechunk/core.py
@@ -259,8 +259,8 @@ class IcechunkCatalog(Catalog):
         xarray_kwargs : dict, optional
             Keyword arguments forwarded to ``xarray.open_zarr()``.
         storage_options : dict, optional
-            fsspec options for *reading the JSON file itself* (not for the
-            Icechunk store — those are embedded in the JSON).
+            obstore config kwargs for *reading the JSON file itself* (not for
+            the Icechunk store — those are embedded in the JSON).
         """
         from .cat import VirtualIcechunkCatalogModel
 
@@ -307,7 +307,9 @@ class IcechunkCatalog(Catalog):
             virtual_chunk_model=self.virtual_chunk_model,
         )
         dir_url = _path_to_url(directory or os.getcwd())
-        obs_store = _obs_from_url(dir_url, config=_filter_config_args(self.storage_options))
+        obs_store = _obs_from_url(
+            dir_url, config=_filter_config_args(self.storage_options)
+        )
         model.save(name, store=obs_store, json_dump_kwargs=json_dump_kwargs)
 
     # ------------------------------------------------------------------

--- a/src/intake_virtual_icechunk/core.py
+++ b/src/intake_virtual_icechunk/core.py
@@ -4,23 +4,27 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from collections.abc import Callable
 from functools import cached_property
 from pathlib import Path
 
-import fsspec
+import obstore
 import pandas as pd
 import polars as pl
 import zarr
 from intake.catalog import Catalog
+from obstore.store import from_url as _obs_from_url
 
 from intake_virtual_icechunk._search import pl_search
 from intake_virtual_icechunk._source import IcechunkDataSource
 from intake_virtual_icechunk.source._containers import VirtualChunkContainerModel
 from intake_virtual_icechunk.utils import (
+    _filter_config_args,
+    _intake_cat_filename,
+    _path_to_url,
     _resolve_storage,
-    _sidecar_url,
 )
 
 if sys.version_info >= (3, 13):
@@ -43,18 +47,21 @@ def _read_sidecar_metadata(
         Path or URI of the Icechunk store directory.
     storage_options :
         Credential/config kwargs for the Icechunk storage backend.  Used as
-        the default fsspec kwargs when *sidecar_options* is ``None``.
+        the default obstore kwargs when *sidecar_options* is ``None``.
     sidecar_options :
-        fsspec kwargs used *only* to open the sidecar file.  When ``None``
+        obstore kwargs used *only* to open the sidecar file.  When ``None``
         the function falls back to *storage_options* (common case: sidecar
         lives in the same bucket).  Pass ``{}`` explicitly to send nothing
-        to fsspec (e.g. sidecar is local, store is remote).
+        to obstore (e.g. sidecar is local, store is remote).
     """
     effective = (
         sidecar_options if sidecar_options is not None else (storage_options or {})
     )
-    with fsspec.open(_sidecar_url(store), **effective) as f:
-        return json.load(f)
+    store_url = _path_to_url(store)
+    obs_store = _obs_from_url(store_url, config=_filter_config_args(effective))
+    fname = _intake_cat_filename(store)
+    content = obstore.get(obs_store, fname).bytes()
+    return json.loads(bytes(content))
 
 
 def _match_query(attrs: dict, query: dict) -> bool:
@@ -299,7 +306,9 @@ class IcechunkCatalog(Catalog):
             storage_options=self.storage_options,
             virtual_chunk_model=self.virtual_chunk_model,
         )
-        model.save(name, directory=directory, json_dump_kwargs=json_dump_kwargs)
+        dir_url = _path_to_url(directory or os.getcwd())
+        obs_store = _obs_from_url(dir_url, config=_filter_config_args(self.storage_options))
+        model.save(name, store=obs_store, json_dump_kwargs=json_dump_kwargs)
 
     # ------------------------------------------------------------------
     # Core catalog interface

--- a/src/intake_virtual_icechunk/core.py
+++ b/src/intake_virtual_icechunk/core.py
@@ -61,7 +61,9 @@ def _read_sidecar_metadata(
     obs_store = _obs_from_url(store_url, config=_filter_config_args(effective))
     fname = _intake_cat_filename(store)
     content = obstore.get(obs_store, fname).bytes()
-    return json.loads(bytes(content))
+    return json.loads(
+        bytes(content)  # double bytes here looks weird but is necessary
+    )
 
 
 def _match_query(attrs: dict, query: dict) -> bool:

--- a/src/intake_virtual_icechunk/source/_build.py
+++ b/src/intake_virtual_icechunk/source/_build.py
@@ -15,10 +15,12 @@ import polars as pl
 import zarr
 from intake_esm.core import esm_datastore
 from intake_esm.utils import MinimalExploder
+from obstore.store import from_url as _obs_from_url
 from virtualizarr import open_virtual_dataset, open_virtual_mfdataset
 
 from intake_virtual_icechunk.source._containers import VirtualChunkContainerModel
 from intake_virtual_icechunk.utils import (
+    _filter_config_args,
     _intake_cat_filename,
     _resolve_storage,
     _resolve_store,
@@ -386,11 +388,11 @@ class IcechunkStoreBuilder:
                 store_options=self.store_options,
             ),
         )
-        model.save(
-            sidecar_fname,
-            directory=self.store_path,
-            storage_options=self.storage_options or None,
+        sidecar_store = _obs_from_url(
+            self.store_path,
+            config=_filter_config_args(self.storage_options),
         )
+        model.save(sidecar_fname, store=sidecar_store)
 
     def _attach_catalog_metadata(
         self,

--- a/src/intake_virtual_icechunk/source/_build.py
+++ b/src/intake_virtual_icechunk/source/_build.py
@@ -30,6 +30,7 @@ from intake_virtual_icechunk.utils import (
 
 if TYPE_CHECKING:
     from obspec_utils.registry import ObjectStoreRegistry
+    from obstore.store import ObjectStore
     from virtualizarr.parsers import (
         DMRPPParser,
         FITSParser,
@@ -389,7 +390,7 @@ class IcechunkStoreBuilder:
                 store_options=self.store_options,
             ),
         )
-        sidecar_store = _obs_from_url(
+        sidecar_store: ObjectStore = _obs_from_url(
             _path_to_url(self.store_path),
             config=_filter_config_args(self.storage_options),
         )

--- a/src/intake_virtual_icechunk/source/_build.py
+++ b/src/intake_virtual_icechunk/source/_build.py
@@ -22,6 +22,7 @@ from intake_virtual_icechunk.source._containers import VirtualChunkContainerMode
 from intake_virtual_icechunk.utils import (
     _filter_config_args,
     _intake_cat_filename,
+    _path_to_url,
     _resolve_storage,
     _resolve_store,
     _resolve_vcc_store,
@@ -389,7 +390,7 @@ class IcechunkStoreBuilder:
             ),
         )
         sidecar_store = _obs_from_url(
-            self.store_path,
+            _path_to_url(self.store_path),
             config=_filter_config_args(self.storage_options),
         )
         model.save(sidecar_fname, store=sidecar_store)

--- a/src/intake_virtual_icechunk/utils.py
+++ b/src/intake_virtual_icechunk/utils.py
@@ -325,7 +325,12 @@ def _filter_config_args(store_options: dict) -> dict:
 
     obstore_opts = copy.deepcopy(store_options)
 
-    icechunk_specific_keys = {"s3_compatible", "force_path_style", "anonymous", "from_env"}
+    icechunk_specific_keys = {
+        "s3_compatible",
+        "force_path_style",
+        "anonymous",
+        "from_env",
+    }
 
     if "endpoint_url" in obstore_opts:
         obstore_opts["endpoint"] = obstore_opts.pop("endpoint_url")

--- a/src/intake_virtual_icechunk/utils.py
+++ b/src/intake_virtual_icechunk/utils.py
@@ -3,6 +3,7 @@ Copyright 2026 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for
 SPDX-License-Identifier: Apache-2.0
 """
 
+import copy
 import os
 import posixpath
 from pathlib import Path
@@ -286,3 +287,50 @@ def _resolve_vcc_store(url_prefix: str, store_options: dict) -> Any:
         f"Unsupported URL prefix scheme: {scheme!r}. "
         "Expected a local path, file://, or s3://."
     )
+
+
+def _path_to_url(path: str | Path) -> str:
+    """
+    Ensure a path has a URL scheme, converting bare local paths to ``file://`` URLs.
+
+    obstore's ``from_url`` requires an explicit scheme; bare POSIX paths such as
+    ``/tmp/store`` are rejected as "relative URL without a base".  This helper
+    normalises them to ``file:///tmp/store`` while leaving cloud URLs (``s3://``,
+    ``gs://``, ``az://``) and already-correct ``file://`` URLs unchanged.
+
+    ``os.path.abspath`` is applied so that relative paths (e.g. used in tests
+    or notebooks) are also resolved correctly.
+    """
+    path_str = str(path)
+    parsed = urlparse(path_str)
+    scheme = parsed.scheme
+
+    # Already has a recognised URL scheme — return as-is.
+    if scheme == "file" or (len(scheme) > 1 and scheme not in ("",)):
+        return path_str
+
+    # Bare local path (no scheme, or single-char Windows drive letter).
+    abs_path = os.path.abspath(path_str)
+    return f"file://{abs_path}"
+
+
+def _filter_config_args(store_options: dict) -> dict:
+    """
+    Translate icechunk-style storage options to obstore config kwargs.
+
+    Keys that are icechunk-specific (not understood by obstore) are dropped.
+    ``endpoint_url`` is renamed to ``endpoint``.  ``anonymous`` is renamed to
+    ``skip_signature`` and only included when it was explicitly set.
+    """
+
+    obstore_opts = copy.deepcopy(store_options)
+
+    icechunk_specific_keys = {"s3_compatible", "force_path_style", "anonymous", "from_env"}
+
+    if "endpoint_url" in obstore_opts:
+        obstore_opts["endpoint"] = obstore_opts.pop("endpoint_url")
+
+    if "anonymous" in obstore_opts:
+        obstore_opts["skip_signature"] = obstore_opts.pop("anonymous")
+
+    return {k: v for k, v in obstore_opts.items() if k not in icechunk_specific_keys}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -128,6 +128,37 @@ class TestVirtualIcechunkCatalogModel:
         )
         assert model.version == "1.0.0"
 
+    def test_load_cloud_url_splits_path_correctly(self):
+        """Regression: load() else-branch (cat.py:88) must split a cloud URL into
+        directory and filename before creating the obstore."""
+        import json
+        from unittest.mock import MagicMock, patch
+
+        sidecar = {
+            "store": "s3://bucket/store.icechunk",
+            "virtual_chunk_model": {
+                "url_prefix": "s3://bucket/data/",
+                "store_type": "PyObjectStoreConfig_S3",
+                "open_kwargs": {},
+            },
+        }
+        mock_get_result = MagicMock()
+        mock_get_result.bytes.return_value = json.dumps(sidecar).encode()
+
+        with (
+            patch("intake_virtual_icechunk.cat._obs_from_url") as mock_from_url,
+            patch(
+                "intake_virtual_icechunk.cat.obstore.get", return_value=mock_get_result
+            ) as mock_get,
+        ):
+            model = VirtualIcechunkCatalogModel.load("s3://bucket/path/to/catalog.json")
+
+        # Directory and filename must be split at the last '/'
+        mock_from_url.assert_called_once()
+        assert mock_from_url.call_args[0][0] == "s3://bucket/path/to"
+        mock_get.assert_called_once_with(mock_from_url.return_value, "catalog.json")
+        assert model.store == "s3://bucket/store.icechunk"
+
 
 class TestIcechunkCatalogFromJson:
     """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -96,6 +96,7 @@ class TestVirtualIcechunkCatalogModel:
         icechunk_store_path = str(icechunk_store_path)
 
         from obstore.store import from_url as _obs_from_url
+
         obs_store = _obs_from_url(f"file://{tmp_path}")
         model.save("my-catalog", store=obs_store)
         json_path = tmp_path / "my-catalog.json"
@@ -194,7 +195,7 @@ class TestIcechunkCatalogFromJson:
 
         This exercises:
         - _sidecar_url correctly locates the sidecar (no file:// mangling)
-        - fsspec.open() can read it
+        - obstore.get() can read it
         - VirtualChunkContainerModel serialises / deserialises intact
         """
         # Open catalog and record the original VCC config

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,7 +95,9 @@ class TestVirtualIcechunkCatalogModel:
         # Turn the path into a string for easier comparison in the JSON output
         icechunk_store_path = str(icechunk_store_path)
 
-        model.save("my-catalog", directory=str(tmp_path))
+        from obstore.store import from_url as _obs_from_url
+        obs_store = _obs_from_url(f"file://{tmp_path}")
+        model.save("my-catalog", store=obs_store)
         json_path = tmp_path / "my-catalog.json"
         assert json_path.exists()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,9 @@ import pytest
 
 from intake_virtual_icechunk.utils import (
     ObjectStoreError,
+    _filter_config_args,
     _intake_cat_filename,
+    _path_to_url,
     _resolve_vcc_store,
     _sidecar_url,
 )
@@ -41,9 +43,9 @@ class TestSidecarUrl:
     def test_file_uri(self):
         # Regression: Path() on POSIX collapses file:///path → file:/path
         result = _sidecar_url("file:///tmp/demo.icechunk")
-        assert (
-            result == "file:///tmp/demo.icechunk/_intake_demo.json"
-        ), f"file:// URI mangled: got {result!r}"
+        assert result == "file:///tmp/demo.icechunk/_intake_demo.json", (
+            f"file:// URI mangled: got {result!r}"
+        )
 
     def test_file_uri_trailing_slash(self):
         result = _sidecar_url("file:///tmp/demo.icechunk/")
@@ -110,3 +112,61 @@ class TestResolveVccStore:
     def test_unknown_scheme_raises(self):
         with pytest.raises(ObjectStoreError, match="Unsupported URL prefix scheme"):
             _resolve_vcc_store("ftp://some-server/path/", {})
+
+
+class TestPathToUrl:
+    def test_bare_absolute_path_gets_file_scheme(self, tmp_path):
+        result = _path_to_url(str(tmp_path))
+        assert result == f"file://{tmp_path}"
+
+    def test_file_scheme_returned_unchanged(self):
+        url = "file:///tmp/my-store.icechunk"
+        assert _path_to_url(url) == url
+
+    def test_s3_scheme_returned_unchanged(self):
+        url = "s3://my-bucket/prefix/store.icechunk"
+        assert _path_to_url(url) == url
+
+    def test_relative_path_is_made_absolute(self):
+        """
+        Bit hard to assert what the path will become here as it depends on the test
+        runner's CWD, but we can at least check that it gets an absolute path and
+        the file scheme.
+        """
+        import os
+
+        result = _path_to_url("relative/path")
+        assert result.startswith("file://")
+        assert os.path.isabs(result[len("file://") :])
+
+
+class TestFilterConfigArgs:
+    def test_empty_dict_returns_empty(self):
+        assert _filter_config_args({}) == {}
+
+    def test_endpoint_url_renamed_to_endpoint(self):
+        result = _filter_config_args({"endpoint_url": "https://example.com"})
+        assert result == {"endpoint": "https://example.com"}
+        assert "endpoint_url" not in result
+
+    def test_anonymous_renamed_to_skip_signature(self):
+        result = _filter_config_args({"anonymous": True})
+        assert result == {"skip_signature": True}
+        assert "anonymous" not in result
+
+    def test_anonymous_false_renamed(self):
+        result = _filter_config_args({"anonymous": False})
+        assert result == {"skip_signature": False}
+
+    def test_anonymous_absent_skip_signature_not_injected(self):
+        # When anonymous is not set, skip_signature must not be added
+        result = _filter_config_args({"region": "us-east-1"})
+        assert "skip_signature" not in result
+
+    def test_icechunk_specific_keys_dropped(self):
+        opts = {"s3_compatible": True, "force_path_style": True, "from_env": True}
+        assert _filter_config_args(opts) == {}
+
+    def test_passthrough_keys_preserved(self):
+        result = _filter_config_args({"region": "ap-southeast-2", "allow_http": False})
+        assert result == {"region": "ap-southeast-2", "allow_http": False}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,9 +43,9 @@ class TestSidecarUrl:
     def test_file_uri(self):
         # Regression: Path() on POSIX collapses file:///path → file:/path
         result = _sidecar_url("file:///tmp/demo.icechunk")
-        assert result == "file:///tmp/demo.icechunk/_intake_demo.json", (
-            f"file:// URI mangled: got {result!r}"
-        )
+        assert (
+            result == "file:///tmp/demo.icechunk/_intake_demo.json"
+        ), f"file:// URI mangled: got {result!r}"
 
     def test_file_uri_trailing_slash(self):
         result = _sidecar_url("file:///tmp/demo.icechunk/")


### PR DESCRIPTION
Impl: Claude Sonnet 4.6

We were using obstore for everything icechunk related, but fsspec for the VirtualChunkContainer model, which I lifted the implementation for from intake-esm.