### PR TITLE
Bump minimum zarr version to 3.2.0 - rectilinear chunk grids.

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -13251,7 +13251,7 @@ packages:
   - typing-extensions
   - virtualizarr
   - xarray
-  - zarr
+  - zarr>=3.2.0
   - pytest ; extra == 'test'
   - pytest-cov ; extra == 'test'
   - myst-nb ; extra == 'docs'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "typing-extensions",
     "virtualizarr",
     "xarray",
-    "zarr",
+    "zarr>=3.2.0",
 ]
 dynamic = ["version"]
 
@@ -78,7 +78,7 @@ platforms = ["osx-arm64", "linux-64"]
 
 [tool.pixi.dependencies]
 intake-esm = "*"
-zarr = "*"
+zarr = ">=3.2.0"
 netcdf4 = ">=1.7.4,<2"
 
 [tool.pixi.feature.icechunk-1.pypi-dependencies]


### PR DESCRIPTION
Still no support for virtualising these yet, but hopefully soon (virtualizarr#954)