### PR TITLE
Remove the 'this is vibe coded' banner in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # intake-virtual-icechunk
 
-> [!WARNING]
-> This package has been scaffolded by Claude but not all of the implementation is complete yet.
-> APIs, class names, and behaviour are all subject to change.
-
 An intake plugin for building and reading [Icechunk](https://icechunk.io) stores via
 [VirtualiZarr](https://virtualizarr.readthedocs.io) and
 [intake-esm](https://intake-esm.readthedocs.io).


### PR DESCRIPTION
Not true any more