### PR TITLE
refactor: Move a bunch of stuff out of `source/_build.py` and into `source/utils.py`

### DIFF
--- a/src/intake_virtual_icechunk/source/_build.py
+++ b/src/intake_virtual_icechunk/source/_build.py
@@ -5,7 +5,6 @@ from collections.abc import Generator, Iterable, Mapping
 
 # Copyright 2026 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -22,6 +21,11 @@ from obstore.store import from_url as _obs_from_url
 from virtualizarr import open_virtual_dataset, open_virtual_mfdataset
 
 from intake_virtual_icechunk.source._containers import VirtualChunkContainerModel
+from intake_virtual_icechunk.source.utils import (
+    DataStoreStructure,
+    GroupEntry,
+    ParserInferenceError,
+)
 from intake_virtual_icechunk.utils import (
     _filter_config_args,
     _intake_cat_filename,
@@ -53,91 +57,6 @@ if TYPE_CHECKING:
         | type[NetCDF3Parser]
         | type[ZarrParser]
     )
-
-
-class IcechunkBuildError(Exception):
-    """Custom exception for errors during the Icechunk store build process."""
-
-    pass
-
-
-class ParserInferenceError(IcechunkBuildError):
-    """Raised when the parser cannot be inferred from the intake-esm catalog."""
-
-    pass
-
-
-class GroupEntryError(IcechunkBuildError):
-    """Raised when a builder entry is missing data required by a build path."""
-
-    pass
-
-
-@dataclass
-class DataStoreStructure:
-    groupby_attrs: list[str]
-    assets_col: str
-
-
-@dataclass
-class GroupEntry:
-    """One logical dataset-group entry consumed by a builder.
-
-    The current intake-esm path can populate all fields, but later sources may
-    only be able to supply a subset. Builder paths should therefore request the
-    specific payload they need via the helper methods below rather than reaching
-    directly into the raw attributes.
-    """
-
-    public_key: str
-    group_attrs: dict[str, Any]
-    metadata_df: pd.DataFrame | None = None
-    source_file_paths: list[str] | None = None
-
-    @classmethod
-    def from_esm_group(
-        cls,
-        *,
-        public_key: str,
-        group_df: pd.DataFrame,
-        groupby_attrs: list[str],
-        assets_col: str,
-    ) -> GroupEntry:
-        """Construct a builder entry from one grouped intake-esm dataframe slice."""
-
-        group_attrs = {
-            attr: group_df[attr].iloc[0]
-            for attr in groupby_attrs
-            if attr in group_df.columns
-        }
-        file_paths: list[str] = group_df[assets_col].tolist()
-        return cls(
-            public_key=public_key,
-            group_attrs=group_attrs,
-            metadata_df=group_df,
-            source_file_paths=file_paths,
-        )
-
-    @property
-    def group_df(self) -> pd.DataFrame:
-        """Return the metadata dataframe required by catalog-shaped builder paths."""
-
-        if self.metadata_df is None:
-            raise GroupEntryError(
-                "Group entry "
-                f"'{self.public_key}' does not include a metadata dataframe."
-            )
-        return self.metadata_df
-
-    @property
-    def file_paths(self) -> list[str]:
-        """Return the source paths required by source-asset builder paths."""
-
-        if not self.source_file_paths:
-            raise GroupEntryError(
-                f"Group entry '{self.public_key}' does not include source file paths."
-            )
-        return self.source_file_paths
 
 
 class AbstractIcechunkStoreBuilder(abc.ABC):

--- a/src/intake_virtual_icechunk/source/utils.py
+++ b/src/intake_virtual_icechunk/source/utils.py
@@ -93,6 +93,12 @@ class GroupEntry:
         )
 
     @property
+    def has_metadata_df(self) -> bool:
+        """Return whether this entry includes rich per-asset metadata rows."""
+
+        return self.metadata_df is not None
+
+    @property
     def group_df(self) -> pd.DataFrame:
         """Return the metadata dataframe required by catalog-shaped builder paths."""
 

--- a/src/intake_virtual_icechunk/source/utils.py
+++ b/src/intake_virtual_icechunk/source/utils.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+# Copyright 2026 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from virtualizarr.parsers import (
+        DMRPPParser,
+        FITSParser,
+        HDFParser,
+        KerchunkJSONParser,
+        KerchunkParquetParser,
+        NetCDF3Parser,
+        ZarrParser,
+    )
+
+    VirtualizarrParser = (
+        type[DMRPPParser]
+        | type[FITSParser]
+        | type[HDFParser]
+        | type[KerchunkJSONParser]
+        | type[KerchunkParquetParser]
+        | type[NetCDF3Parser]
+        | type[ZarrParser]
+    )
+
+
+class IcechunkBuildError(Exception):
+    """Custom exception for errors during the Icechunk store build process."""
+
+    pass
+
+
+class ParserInferenceError(IcechunkBuildError):
+    """Raised when the parser cannot be inferred from the intake-esm catalog."""
+
+    pass
+
+
+class GroupEntryError(IcechunkBuildError):
+    """Raised when a builder entry is missing data required by a build path."""
+
+    pass
+
+
+@dataclass
+class DataStoreStructure:
+    groupby_attrs: list[str]
+    assets_col: str
+
+
+@dataclass
+class GroupEntry:
+    """One logical dataset-group entry consumed by a builder.
+
+    The current intake-esm path can populate all fields, but later sources may
+    only be able to supply a subset. Builder paths should therefore request the
+    specific payload they need via the helper methods below rather than reaching
+    directly into the raw attributes.
+    """
+
+    public_key: str
+    group_attrs: dict[str, Any]
+    metadata_df: pd.DataFrame | None = None
+    source_file_paths: list[str] | None = None
+
+    @classmethod
+    def from_esm_group(
+        cls,
+        *,
+        public_key: str,
+        group_df: pd.DataFrame,
+        groupby_attrs: list[str],
+        assets_col: str,
+    ) -> GroupEntry:
+        """Construct a builder entry from one grouped intake-esm dataframe slice."""
+
+        group_attrs = {
+            attr: group_df[attr].iloc[0]
+            for attr in groupby_attrs
+            if attr in group_df.columns
+        }
+        file_paths: list[str] = group_df[assets_col].tolist()
+        return cls(
+            public_key=public_key,
+            group_attrs=group_attrs,
+            metadata_df=group_df,
+            source_file_paths=file_paths,
+        )
+
+    @property
+    def group_df(self) -> pd.DataFrame:
+        """Return the metadata dataframe required by catalog-shaped builder paths."""
+
+        if self.metadata_df is None:
+            raise GroupEntryError(
+                "Group entry "
+                f"'{self.public_key}' does not include a metadata dataframe."
+            )
+        return self.metadata_df
+
+    @property
+    def file_paths(self) -> list[str]:
+        """Return the source paths required by source-asset builder paths."""
+
+        if not self.source_file_paths:
+            raise GroupEntryError(
+                f"Group entry '{self.public_key}' does not include source file paths."
+            )
+        return self.source_file_paths

--- a/tests/test_source_build.py
+++ b/tests/test_source_build.py
@@ -14,7 +14,7 @@ import tlz
 import virtualizarr
 from access_nri_intake.source.builders import AccessOm2Builder
 from dotenv import load_dotenv
-from intake_esm import esm_datastore
+from intake_esm.core import esm_datastore
 from obstore.store import ObjectStore, from_url
 from pandas.testing import assert_frame_equal
 
@@ -23,7 +23,7 @@ from intake_virtual_icechunk.source import (
     IcechunkStoreBuilder,
     VirtualIcechunkStoreBuilder,
 )
-from intake_virtual_icechunk.source._build import GroupEntry, GroupEntryError
+from intake_virtual_icechunk.source.utils import GroupEntry, GroupEntryError
 from intake_virtual_icechunk.utils import _intake_cat_filename
 
 __all__ = ["VirtualIcechunkStoreBuilder", "pytest"]


### PR DESCRIPTION
Utils is a pretty shonky name too, but we can clean that up later. 

I think this just makes codebase nav easier.