### PR TITLE
test: fix pytest test classes silently skipped due to __init__

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,31 +21,20 @@ def sample_data() -> Path:
 
 @pytest.fixture(scope="session")
 def groups():
+    """Independent manifest of the dataset groups in the access-om2 fixture store.
+
+    These are the Zarr group keys produced by ``icechunk_localstore_path`` (built
+    from the committed access-om2 sample data via ``AccessOm2Builder``). Kept here
+    as a hand-maintained expectation so the catalog's key listing is checked
+    against something other than itself.
+    """
     return [
-        {
-            "key": "CMIP.BCC.BCC-ESM1.historical",
-            "attrs": {
-                "source_id": "BCC-ESM1",
-                "experiment_id": "historical",
-                "member_id": "r1i1p1f1",
-            },
-        },
-        {
-            "key": "CMIP.BCC.BCC-ESM1.ssp585",
-            "attrs": {
-                "source_id": "BCC-ESM1",
-                "experiment_id": "ssp585",
-                "member_id": "r1i1p1f1",
-            },
-        },
-        {
-            "key": "CMIP.MRI.MRI-ESM2-0.historical",
-            "attrs": {
-                "source_id": "MRI-ESM2-0",
-                "experiment_id": "historical",
-                "member_id": "r1i1p1f1",
-            },
-        },
+        {"key": "ocean.1mon.nv:2.scalar_axis:1.mean"},
+        {"key": "ocean.1mon.nv:2.xt_ocean:1.yt_ocean:1.mean"},
+        {"key": "ocean.1mon.xt_ocean:1.yt_ocean:1.mean"},
+        {"key": "ocean.1yr.nv:2.st_ocean:1.xt_ocean:1.yt_ocean:1.mean"},
+        {"key": "ocean.fx.xt_ocean:1.yt_ocean:1.point"},
+        {"key": "seaIce.1mon.d2:2.ni:1.nj:1.mean"},
     ]
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -340,7 +340,8 @@ class TestIcechunkCatalogConstructorKwargs:
 class TestIcechunkCatalogKeys:
     """Tests for the catalog mapping-style key interface."""
 
-    def __init__(self, groups):
+    @pytest.fixture(autouse=True)
+    def _set_all_keys(self, groups):
         self.all_keys = [g["key"] for g in groups]
 
     def test_keys_returns_all_groups(self, icechunk_localstore_path):
@@ -523,19 +524,23 @@ class TestIcechunkCatalogSearch:
 class TestIcechunkCatalogDf:
     """Tests for the catalog metadata DataFrame."""
 
-    def __init__(self, groups):
+    @pytest.fixture(autouse=True)
+    def _set_all_keys(self, groups):
         self.all_keys = [g["key"] for g in groups]
 
-    def test_df_has_key_column(self, icechunk_localstore_path):
+    def test_df_key_is_index(self, icechunk_localstore_path):
         cat = IcechunkCatalog(store=icechunk_localstore_path)
         df = cat.df
-        assert "key" in df.columns
+        # df sets the group key as the index (set_index("key", drop=True)),
+        # so "key" is the index name, not a column.
+        assert df.index.name == "key"
+        assert "key" not in df.columns
 
     def test_df_has_attr_columns(self, icechunk_localstore_path):
         cat = IcechunkCatalog(store=icechunk_localstore_path)
         df = cat.df
-        assert "source_id" in df.columns
-        assert "experiment_id" in df.columns
+        assert "filename" in df.columns
+        assert "title" in df.columns
 
     def test_df_row_count(self, icechunk_localstore_path):
         cat = IcechunkCatalog(store=icechunk_localstore_path)
@@ -543,13 +548,15 @@ class TestIcechunkCatalogDf:
 
     def test_df_keys_match(self, icechunk_localstore_path):
         cat = IcechunkCatalog(store=icechunk_localstore_path)
-        assert sorted(cat.df["key"].tolist()) == sorted(self.all_keys)
+        assert sorted(cat.df.index.tolist()) == sorted(self.all_keys)
 
     def test_df_filtered_by_search(self, icechunk_localstore_path):
         cat = IcechunkCatalog(store=icechunk_localstore_path)
-        result = cat.search(source_id="BCC-ESM1")
+        filename_val = cat.df["filename"].dropna().iloc[0]
+        result = cat.search(filename=filename_val)
         df = result.df
-        assert all(df["source_id"] == "BCC-ESM1")
+        assert len(df) > 0
+        assert all(df["filename"] == filename_val)
 
 
 class TestIcechunkCatalogToDatasetDict:


### PR DESCRIPTION
TestIcechunkCatalogKeys and TestIcechunkCatalogDf each defined `__init__(self, groups)`. pytest instantiates test classes itself with no args and refuses to collect any class with a constructor, emitting only a PytestCollectionWarning — so every method in both classes was silently never run (~9 tests).

Replace each constructor with an autouse fixture, the idiomatic way to attach fixture-derived state to self. Un-skipping then revealed the tests encoded a stale CMIP store: the groups fixture described 3 CMIP groups while icechunk_localstore_path actually builds a 6-group access-om2 store.

- Rewrite the groups fixture to list the real access-om2 group keys.
- Fix drifted assertions: key is the df index (not a column); assert attrs that exist on this store (filename/title); derive the search filter value from df like the existing search tests.