### PR TITLE
feat: add rechunk()/sharding to IcechunkStoreBuilder (real-data builder)

### DIFF
--- a/src/intake_virtual_icechunk/source/_build.py
+++ b/src/intake_virtual_icechunk/source/_build.py
@@ -5,6 +5,7 @@ import warnings
 from collections.abc import Generator, Iterable, Mapping
 from dataclasses import dataclass
 from functools import cached_property
+
 # Copyright 2026 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
@@ -25,24 +26,34 @@ from intake_esm.utils import MinimalExploder
 from obstore.store import from_url as _obs_from_url
 from virtualizarr import open_virtual_dataset, open_virtual_mfdataset
 
-from intake_virtual_icechunk.source._containers import \
-    VirtualChunkContainerModel
-from intake_virtual_icechunk.source.utils import (DataStoreStructure,
-                                                  GroupEntry,
-                                                  ParserInferenceError)
-from intake_virtual_icechunk.utils import (_filter_config_args,
-                                           _intake_cat_filename, _path_to_url,
-                                           _representative_source_size,
-                                           _resolve_storage, _resolve_store,
-                                           _resolve_vcc_store)
+from intake_virtual_icechunk.source._containers import VirtualChunkContainerModel
+from intake_virtual_icechunk.source.utils import (
+    DataStoreStructure,
+    GroupEntry,
+    ParserInferenceError,
+)
+from intake_virtual_icechunk.utils import (
+    _filter_config_args,
+    _intake_cat_filename,
+    _path_to_url,
+    _representative_source_size,
+    _resolve_storage,
+    _resolve_store,
+    _resolve_vcc_store,
+)
 
 if TYPE_CHECKING:
     from obspec_utils.registry import ObjectStoreRegistry
     from obstore.store import ObjectStore
-    from virtualizarr.parsers import (DMRPPParser, FITSParser, HDFParser,
-                                      KerchunkJSONParser,
-                                      KerchunkParquetParser, NetCDF3Parser,
-                                      ZarrParser)
+    from virtualizarr.parsers import (
+        DMRPPParser,
+        FITSParser,
+        HDFParser,
+        KerchunkJSONParser,
+        KerchunkParquetParser,
+        NetCDF3Parser,
+        ZarrParser,
+    )
 
     VirtualizarrParser = (
         type[DMRPPParser]
@@ -747,7 +758,7 @@ class IcechunkStoreBuilder(AbstractIcechunkStoreBuilder):
         if isinstance(shards, str) and shards == "auto":
             shards = _representative_source_size(self._source_file_paths())
         norm_shards = _normalize_size_arg(shards, "shards", allow_auto=False)
-        self._rechunk = _RechunkSpec(chunks=norm_chunks, shards=norm_shards)
+        self._rechunk = _RechunkSpec(chunks=norm_chunks, shards=norm_shards)  # type: ignore[arg-type]
         return self
 
     def _apply_rechunking(self, ds: xr.Dataset) -> xr.Dataset:

--- a/src/intake_virtual_icechunk/source/_build.py
+++ b/src/intake_virtual_icechunk/source/_build.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import abc
+import warnings
 from collections.abc import Generator, Iterable, Mapping
+from dataclasses import dataclass
 from functools import cached_property
 
 # Copyright 2026 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
@@ -9,12 +11,15 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import dask
 import icechunk
 import intake
 import pandas as pd
 import polars as pl
 import xarray as xr
 import zarr
+from dask.array.core import normalize_chunks
+from dask.utils import parse_bytes
 from icechunk.xarray import to_icechunk
 from intake_esm.core import esm_datastore
 from intake_esm.utils import MinimalExploder
@@ -31,6 +36,7 @@ from intake_virtual_icechunk.utils import (
     _filter_config_args,
     _intake_cat_filename,
     _path_to_url,
+    _representative_source_size,
     _resolve_storage,
     _resolve_store,
     _resolve_vcc_store,
@@ -685,6 +691,8 @@ class IcechunkStoreBuilder(AbstractIcechunkStoreBuilder):
             cols_to_deiter=cols_to_deiter,
             xarray_kwargs=xarray_kwargs,
         )
+        # Rechunk/shard config; None means "write source chunking unchanged".
+        self._rechunk: _RechunkSpec | None = None
 
     def __repr__(self) -> str:
         """Return a multiline representation showing the builder configuration."""
@@ -704,11 +712,67 @@ class IcechunkStoreBuilder(AbstractIcechunkStoreBuilder):
 
         return "write"
 
+    def _source_file_paths(self) -> list[str]:
+        """All source asset paths across the datastore (used to size auto shards)."""
+        esmcat = self.esm_ds.esmcat
+        return esmcat.df[esmcat.assets.column_name].tolist()
+
+    def rechunk(
+        self,
+        chunks: str | int | dict[str, int] | None = None,
+        shards: str | int | dict[str, int] | None = None,
+    ) -> IcechunkStoreBuilder:
+        """Configure re-chunking (and optional zarr v3 sharding) applied at build.
+
+        Call before :meth:`build`. If never called, source chunking is written
+        unchanged. Returns ``self`` so calls can be chained.
+
+        Parameters
+        ----------
+        chunks :
+            On-disk zarr chunk shape. One of:
+
+            * ``None`` — inherit the source file chunking (default).
+            * ``"auto"`` — let dask pick a shape using its configured
+              ``array.chunk-size``.
+            * a byte size — ``"128MiB"`` / ``"128"`` (128 bytes) / an ``int`` of
+              bytes (parsed by :func:`dask.utils.parse_bytes`); dask picks a shape
+              hitting roughly that size.
+            * a mapping ``{dim: length}`` — explicit per-dimension chunk lengths;
+              dimensions not listed keep their source chunking.
+        shards :
+            On-disk zarr v3 shard shape (a shard bundles many chunks into one
+            storage object). One of:
+
+            * ``None`` — no sharding (default).
+            * ``"auto"`` — target the median on-disk size of the first ~10 source
+              files (≈ one shard object per input file). Resolved now, here.
+            * a byte size — as for *chunks*.
+            * a mapping ``{dim: length}`` — explicit per-dimension shard lengths.
+
+            A shard must be an integer multiple of the chunk on every dimension; a
+            shard smaller than the chunk disables sharding for that variable (with a
+            warning).
+        """
+        norm_chunks = _normalize_size_arg(chunks, "chunks", allow_auto=True)
+        if isinstance(shards, str) and shards == "auto":
+            shards = _representative_source_size(self._source_file_paths())
+        norm_shards = _normalize_size_arg(shards, "shards", allow_auto=False)
+        self._rechunk = _RechunkSpec(chunks=norm_chunks, shards=norm_shards)
+        return self
+
+    def _apply_rechunking(self, ds: xr.Dataset) -> xr.Dataset:
+        """Apply the configured rechunk/shard spec to *ds* (no-op if unset)."""
+        if self._rechunk is None:
+            return ds
+        return _rechunk_dataset(ds, self._rechunk)
+
     def _write_entry(self, store: icechunk.IcechunkStore, entry: GroupEntry) -> None:
         """Write one real-data group into an open Icechunk transaction."""
 
         try:
             with xr.open_mfdataset(entry.file_paths, **entry.xarray_kwargs) as ds:
+                ds = self._apply_rechunking(ds)
                 to_icechunk(ds, store.session, group=entry.public_key, mode="a")
         except Exception as exc:
             if not self._is_concat_dim_order_error(exc):
@@ -719,6 +783,7 @@ class IcechunkStoreBuilder(AbstractIcechunkStoreBuilder):
                 entry.file_paths[0],
                 **kwargs,
             ) as ds:
+                ds = self._apply_rechunking(ds)
                 to_icechunk(
                     ds,
                     store.session,
@@ -799,3 +864,149 @@ def _filter_kwargs(kwargs: dict) -> dict:
             "concat_dim",
         ]
     }
+
+
+@dataclass
+class _RechunkSpec:
+    """Normalized rechunk/shard configuration set by ``IcechunkStoreBuilder.rechunk``.
+
+    ``chunks`` is ``None`` (native) | ``"auto"`` | an ``int`` of bytes | a
+    ``{dim: length}`` mapping. ``shards`` is ``None`` (off) | an ``int`` of bytes |
+    a ``{dim: length}`` mapping (``"auto"`` is resolved to bytes when ``rechunk``
+    is called).
+    """
+
+    chunks: str | int | dict[str, int] | None
+    shards: int | dict[str, int] | None
+
+
+def _validate_shape_dict(value: dict, name: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for dim, length in value.items():
+        if isinstance(length, bool) or not isinstance(length, int) or length <= 0:
+            raise ValueError(
+                f"{name} mapping values must be positive integers; "
+                f"got {dim!r}: {length!r}."
+            )
+        out[str(dim)] = int(length)
+    return out
+
+
+def _normalize_size_arg(
+    value: str | int | dict | None, name: str, *, allow_auto: bool
+) -> str | int | dict[str, int] | None:
+    """Normalize a ``chunks``/``shards`` argument to None | "auto" | int | dict."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return _validate_shape_dict(value, name)
+    if isinstance(value, bool):
+        raise TypeError(f"{name} must not be a bool; got {value!r}.")
+    if isinstance(value, int):
+        if value <= 0:
+            raise ValueError(f"{name} byte size must be positive; got {value!r}.")
+        return value
+    if isinstance(value, str):
+        if value == "auto":
+            if not allow_auto:
+                raise ValueError(f"{name}='auto' should already be resolved.")
+            return "auto"
+        return int(parse_bytes(value))  # raises ValueError on an unparseable string
+    raise TypeError(
+        f"{name} must be None, 'auto', a byte size (str/int), or a "
+        f"{{dim: length}} mapping; got {type(value).__name__}."
+    )
+
+
+def _inner_chunk_shape(var: xr.DataArray) -> dict[str, int]:
+    """Per-dimension on-disk chunk length for *var* (first dask block, or full)."""
+    if var.chunks is None:
+        return {dim: int(var.sizes[dim]) for dim in var.dims}
+    return {dim: int(var.chunksizes[dim][0]) for dim in var.dims}
+
+
+def _ceil_to_multiple(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _resolve_shard_shape(
+    name: str,
+    var: xr.DataArray,
+    chunk_by_dim: dict[str, int],
+    shards: int | dict[str, int],
+) -> dict[str, int] | None:
+    """Resolve the shard shape for *var*, or None to skip sharding it (with warning).
+
+    Byte targets delegate the base shape to dask, then snap each dimension up to a
+    multiple of the chunk. Explicit dicts default unlisted dimensions to one chunk.
+    A shard smaller than the chunk on any dimension disables sharding for *var*.
+    """
+    if isinstance(shards, dict):
+        desired = {dim: shards.get(dim, chunk_by_dim[dim]) for dim in var.dims}
+    else:
+        # A byte target below one chunk can't make a valid (>= 1 chunk) shard;
+        # disable sharding for this variable rather than silently using 1x chunk.
+        chunk_bytes = var.dtype.itemsize
+        for length in chunk_by_dim.values():
+            chunk_bytes *= length
+        if int(shards) < chunk_bytes:
+            warnings.warn(
+                f"Requested shard size ({int(shards)} bytes) for variable "
+                f"{name!r} is smaller than one chunk ({chunk_bytes} bytes); "
+                f"writing {name!r} unsharded.",
+                stacklevel=3,
+            )
+            return None
+        ideal = normalize_chunks(
+            "auto", shape=var.shape, dtype=var.dtype, limit=int(shards)
+        )
+        desired = {
+            dim: max(1, round(ideal[i][0] / chunk_by_dim[dim])) * chunk_by_dim[dim]
+            for i, dim in enumerate(var.dims)
+        }
+
+    shard: dict[str, int] = {}
+    for dim in var.dims:
+        chunk_len = chunk_by_dim[dim]
+        target = desired[dim]
+        if target < chunk_len:
+            warnings.warn(
+                f"Requested shard for variable {name!r} is smaller than its chunk "
+                f"on dimension {dim!r} ({target} < {chunk_len}); writing "
+                f"{name!r} unsharded.",
+                stacklevel=3,
+            )
+            return None
+        # Shards must be an integer multiple of the chunk; cap at the padded extent.
+        target = _ceil_to_multiple(target, chunk_len)
+        shard[dim] = min(target, _ceil_to_multiple(int(var.sizes[dim]), chunk_len))
+    return shard
+
+
+def _rechunk_dataset(ds: xr.Dataset, spec: _RechunkSpec) -> xr.Dataset:
+    """Apply *spec* to *ds*: rechunk the dask graph and set zarr chunk/shard encoding."""
+    if spec.chunks is not None:
+        if isinstance(spec.chunks, dict):
+            ds = ds.chunk(spec.chunks)
+        elif spec.chunks == "auto":
+            ds = ds.chunk("auto")
+        else:  # int bytes -> let dask pick the shape for that target size
+            with dask.config.set({"array.chunk-size": int(spec.chunks)}):
+                ds = ds.chunk("auto")
+
+    if spec.shards is not None:
+        for name in list(ds.data_vars):
+            var = ds[name]
+            if not var.dims:
+                continue  # scalar; nothing to shard
+            chunk_by_dim = _inner_chunk_shape(var)
+            shard_by_dim = _resolve_shard_shape(name, var, chunk_by_dim, spec.shards)
+            if shard_by_dim is None:
+                continue
+            # Align dask blocks to whole shards so each task writes one shard, and
+            # pin both the inner chunk and the shard in the zarr encoding.
+            ds[name] = var.chunk(shard_by_dim)
+            ds[name].encoding["chunks"] = tuple(chunk_by_dim[d] for d in var.dims)
+            ds[name].encoding["shards"] = tuple(shard_by_dim[d] for d in var.dims)
+
+    return ds

--- a/src/intake_virtual_icechunk/source/_build.py
+++ b/src/intake_virtual_icechunk/source/_build.py
@@ -1013,7 +1013,13 @@ def _rechunk_dataset(ds: xr.Dataset, spec: _RechunkSpec) -> xr.Dataset:
             if shard_by_dim is None:
                 continue
             # Align dask blocks to whole shards so each task writes one shard, and
-            # pin both the inner chunk and the shard in the zarr encoding.            ds[name] = var.chunk(shard_by_dim)
+            # pin both the inner chunk and the shard in the zarr encoding. Both are
+            # required (verified on icechunk 2.x): xarray treats the shard as the
+            # write unit, so its safe-chunks check demands each dask block equal one
+            # whole shard, and encoding["chunks"] pins the inner read chunk within
+            # it. Omitting either raises "encoding['chunks'] ... would overlap
+            # multiple Dask chunks".
+            ds[name] = var.chunk(shard_by_dim)
             ds[name].encoding["chunks"] = tuple(chunk_by_dim[d] for d in var.dims)
             ds[name].encoding["shards"] = tuple(shard_by_dim[d] for d in var.dims)
 

--- a/src/intake_virtual_icechunk/source/_build.py
+++ b/src/intake_virtual_icechunk/source/_build.py
@@ -5,7 +5,6 @@ import warnings
 from collections.abc import Generator, Iterable, Mapping
 from dataclasses import dataclass
 from functools import cached_property
-
 # Copyright 2026 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
@@ -26,34 +25,24 @@ from intake_esm.utils import MinimalExploder
 from obstore.store import from_url as _obs_from_url
 from virtualizarr import open_virtual_dataset, open_virtual_mfdataset
 
-from intake_virtual_icechunk.source._containers import VirtualChunkContainerModel
-from intake_virtual_icechunk.source.utils import (
-    DataStoreStructure,
-    GroupEntry,
-    ParserInferenceError,
-)
-from intake_virtual_icechunk.utils import (
-    _filter_config_args,
-    _intake_cat_filename,
-    _path_to_url,
-    _representative_source_size,
-    _resolve_storage,
-    _resolve_store,
-    _resolve_vcc_store,
-)
+from intake_virtual_icechunk.source._containers import \
+    VirtualChunkContainerModel
+from intake_virtual_icechunk.source.utils import (DataStoreStructure,
+                                                  GroupEntry,
+                                                  ParserInferenceError)
+from intake_virtual_icechunk.utils import (_filter_config_args,
+                                           _intake_cat_filename, _path_to_url,
+                                           _representative_source_size,
+                                           _resolve_storage, _resolve_store,
+                                           _resolve_vcc_store)
 
 if TYPE_CHECKING:
     from obspec_utils.registry import ObjectStoreRegistry
     from obstore.store import ObjectStore
-    from virtualizarr.parsers import (
-        DMRPPParser,
-        FITSParser,
-        HDFParser,
-        KerchunkJSONParser,
-        KerchunkParquetParser,
-        NetCDF3Parser,
-        ZarrParser,
-    )
+    from virtualizarr.parsers import (DMRPPParser, FITSParser, HDFParser,
+                                      KerchunkJSONParser,
+                                      KerchunkParquetParser, NetCDF3Parser,
+                                      ZarrParser)
 
     VirtualizarrParser = (
         type[DMRPPParser]
@@ -883,7 +872,7 @@ class _RechunkSpec:
 def _validate_shape_dict(value: dict, name: str) -> dict[str, int]:
     out: dict[str, int] = {}
     for dim, length in value.items():
-        if isinstance(length, bool) or not isinstance(length, int) or length <= 0:
+        if not isinstance(length, int) or length <= 0:
             raise ValueError(
                 f"{name} mapping values must be positive integers; "
                 f"got {dim!r}: {length!r}."
@@ -900,8 +889,6 @@ def _normalize_size_arg(
         return None
     if isinstance(value, dict):
         return _validate_shape_dict(value, name)
-    if isinstance(value, bool):
-        raise TypeError(f"{name} must not be a bool; got {value!r}.")
     if isinstance(value, int):
         if value <= 0:
             raise ValueError(f"{name} byte size must be positive; got {value!r}.")
@@ -919,13 +906,21 @@ def _normalize_size_arg(
 
 
 def _inner_chunk_shape(var: xr.DataArray) -> dict[str, int]:
-    """Per-dimension on-disk chunk length for *var* (first dask block, or full)."""
+    """Per-dimension on-disk chunk length for *var* (first dask block, or full).
+
+    ``var.chunksizes[dim]`` is a tuple of the dask block lengths along *dim*
+    (e.g. ``(12, 12, 6)`` for a size-30 dim chunked at 12). We take ``[0]`` —
+    the first block — as the representative uniform chunk length, which is what
+    zarr writes for every chunk but the (possibly short) last one. If *var* is
+    not dask-backed (``var.chunks is None``) the whole dimension is one chunk.
+    """
     if var.chunks is None:
         return {dim: int(var.sizes[dim]) for dim in var.dims}
     return {dim: int(var.chunksizes[dim][0]) for dim in var.dims}
 
 
 def _ceil_to_multiple(value: int, multiple: int) -> int:
+    """Round *value* up to the nearest integer multiple of *multiple*."""
     return ((value + multiple - 1) // multiple) * multiple
 
 
@@ -960,6 +955,9 @@ def _resolve_shard_shape(
         ideal = normalize_chunks(
             "auto", shape=var.shape, dtype=var.dtype, limit=int(shards)
         )
+        # ``ideal`` is dask's block shape hitting the byte target, but a shard must
+        # tile the chunk grid, so snap each dimension to the nearest whole number
+        # of chunks (at least one). e.g. ideal=50, chunk=12 -> round(50/12)=4 -> 48.
         desired = {
             dim: max(1, round(ideal[i][0] / chunk_by_dim[dim])) * chunk_by_dim[dim]
             for i, dim in enumerate(var.dims)
@@ -1004,8 +1002,7 @@ def _rechunk_dataset(ds: xr.Dataset, spec: _RechunkSpec) -> xr.Dataset:
             if shard_by_dim is None:
                 continue
             # Align dask blocks to whole shards so each task writes one shard, and
-            # pin both the inner chunk and the shard in the zarr encoding.
-            ds[name] = var.chunk(shard_by_dim)
+            # pin both the inner chunk and the shard in the zarr encoding.            ds[name] = var.chunk(shard_by_dim)
             ds[name].encoding["chunks"] = tuple(chunk_by_dim[d] for d in var.dims)
             ds[name].encoding["shards"] = tuple(shard_by_dim[d] for d in var.dims)
 

--- a/src/intake_virtual_icechunk/utils.py
+++ b/src/intake_virtual_icechunk/utils.py
@@ -3,16 +3,20 @@ Copyright 2026 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for
 SPDX-License-Identifier: Apache-2.0
 """
 
+import asyncio
 import copy
 import os
 import posixpath
+import statistics
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 import icechunk
+import obstore
 from obspec_utils.registry import ObjectStoreRegistry
 from obstore.store import AzureStore, GCSStore, LocalStore, S3Store
+from obstore.store import from_url as _obs_from_url
 
 __stores__ = ["LocalStore", "S3Store", "GCSStore", "AzureStore"]
 
@@ -318,6 +322,49 @@ def _path_to_url(path: str | Path) -> str:
     # Bare local path (no scheme, or single-char Windows drive letter).
     abs_path = os.path.abspath(path_str)
     return f"file://{abs_path}"
+
+
+async def _head_source_sizes(paths: list[str], config: dict | None) -> list[int]:
+    """HEAD each path concurrently and return the sizes that succeeded.
+
+    Failures (missing file, permission error, ...) are skipped rather than
+    raising, so a single bad path does not sink the whole sample.
+    """
+
+    async def _one(path: str) -> int:
+        url = _path_to_url(path)
+        dir_url, _, name = url.rpartition("/")
+        store = (
+            _obs_from_url(dir_url, config=config) if config else _obs_from_url(dir_url)
+        )
+        meta = await obstore.head_async(store, name)
+        return int(meta["size"])
+
+    results = await asyncio.gather(*(_one(p) for p in paths), return_exceptions=True)
+    return [r for r in results if isinstance(r, int)]
+
+
+def _representative_source_size(
+    paths: list[str], n: int = 10, config: dict | None = None
+) -> int:
+    """Median on-disk size (bytes) of the first *n* source files.
+
+    Used to pick a shard byte-target for ``shards="auto"`` so that one shard
+    object holds roughly the data of one input file. The median is robust to a
+    single oddly-sized file; HEAD failures are skipped (see
+    :func:`_head_source_sizes`). Uses default/environment obstore config.
+    """
+    sample = list(paths)[:n]
+    if not sample:
+        raise ObjectStoreError("No source file paths available to size shards.")
+
+    sizes = asyncio.run(_head_source_sizes(sample, config))
+    if not sizes:
+        raise ObjectStoreError(
+            f"Could not HEAD any of the {len(sample)} sampled source files "
+            "to determine an automatic shard size."
+        )
+    return int(statistics.median(sizes))
 
 
 def _filter_config_args(store_options: dict) -> dict:

--- a/tests/test_source_build.py
+++ b/tests/test_source_build.py
@@ -1059,10 +1059,6 @@ class TestZarrIcechunkStoreBuilder:
         assert len(builder.failed_list) == len(builder.esm_ds.keys())
         assert set(fl[0] for fl in builder.failed_list) == set(builder.esm_ds.keys())
 
-    # ------------------------------------------------------------------
-    # rechunk() / sharding
-    # ------------------------------------------------------------------
-
     def _builder(self, datastore_path, esm_kwargs, store_path):
         return IcechunkStoreBuilder(
             esm_datastore_path=datastore_path,
@@ -1090,6 +1086,7 @@ class TestZarrIcechunkStoreBuilder:
         builder = self._builder(
             local_om2_datastore_path, intake_esm_kwargs, tmpdir / "s.icechunk"
         )
+        assert builder._rechunk is None
         assert builder.rechunk(chunks="1MiB") is builder
         assert builder._rechunk is not None
 
@@ -1108,7 +1105,7 @@ class TestZarrIcechunkStoreBuilder:
         with pytest.raises(ValueError):
             _normalize_size_arg({"time": 0}, "chunks", allow_auto=True)
         with pytest.raises(TypeError):
-            _normalize_size_arg(True, "chunks", allow_auto=True)
+            _normalize_size_arg([1, 2], "chunks", allow_auto=True)
         with pytest.raises(ValueError):
             _normalize_size_arg("auto", "shards", allow_auto=False)
 

--- a/tests/test_source_build.py
+++ b/tests/test_source_build.py
@@ -12,6 +12,8 @@ import pandas as pd
 import pytest
 import tlz
 import virtualizarr
+import xarray as xr
+import zarr
 from access_nri_intake.source.builders import AccessOm2Builder
 from dotenv import load_dotenv
 from intake_esm.core import esm_datastore
@@ -23,8 +25,16 @@ from intake_virtual_icechunk.source import (
     IcechunkStoreBuilder,
     VirtualIcechunkStoreBuilder,
 )
+from intake_virtual_icechunk.source._build import (
+    _normalize_size_arg,
+    _rechunk_dataset,
+    _RechunkSpec,
+)
 from intake_virtual_icechunk.source.utils import GroupEntry, GroupEntryError
-from intake_virtual_icechunk.utils import _intake_cat_filename
+from intake_virtual_icechunk.utils import (
+    _intake_cat_filename,
+    _representative_source_size,
+)
 
 __all__ = ["VirtualIcechunkStoreBuilder", "pytest"]
 
@@ -1048,6 +1058,136 @@ class TestZarrIcechunkStoreBuilder:
 
         assert len(builder.failed_list) == len(builder.esm_ds.keys())
         assert set(fl[0] for fl in builder.failed_list) == set(builder.esm_ds.keys())
+
+    # ------------------------------------------------------------------
+    # rechunk() / sharding
+    # ------------------------------------------------------------------
+
+    def _builder(self, datastore_path, esm_kwargs, store_path):
+        return IcechunkStoreBuilder(
+            esm_datastore_path=datastore_path,
+            icechunk_store_path=store_path,
+            esm_datastore_kwargs=esm_kwargs,
+        )
+
+    @staticmethod
+    def _multidim_data_arrays(store_path) -> dict:
+        """Return {path: zarr.Array} for every >=2-D array in the built store."""
+        repo = icechunk.Repository.open(
+            icechunk.local_filesystem_storage(str(store_path))
+        )
+        root = zarr.open_group(repo.readonly_session("main").store, mode="r")
+        arrays = {}
+        for gname, group in root.groups():
+            for aname, arr in group.arrays():
+                if arr.ndim >= 2:
+                    arrays[f"{gname}/{aname}"] = arr
+        return arrays
+
+    def test_rechunk_returns_self(
+        self, local_om2_datastore_path, intake_esm_kwargs, tmpdir
+    ):
+        builder = self._builder(
+            local_om2_datastore_path, intake_esm_kwargs, tmpdir / "s.icechunk"
+        )
+        assert builder.rechunk(chunks="1MiB") is builder
+        assert builder._rechunk is not None
+
+    def test_normalize_size_arg(self):
+        assert _normalize_size_arg(None, "chunks", allow_auto=True) is None
+        assert _normalize_size_arg("auto", "chunks", allow_auto=True) == "auto"
+        assert _normalize_size_arg("128", "chunks", allow_auto=True) == 128
+        assert _normalize_size_arg("128MiB", "chunks", allow_auto=True) == 128 * 1024**2
+        assert _normalize_size_arg({"time": 3}, "chunks", allow_auto=True) == {
+            "time": 3
+        }
+
+    def test_normalize_size_arg_invalid(self):
+        with pytest.raises(ValueError):
+            _normalize_size_arg("not-a-size", "chunks", allow_auto=True)
+        with pytest.raises(ValueError):
+            _normalize_size_arg({"time": 0}, "chunks", allow_auto=True)
+        with pytest.raises(TypeError):
+            _normalize_size_arg(True, "chunks", allow_auto=True)
+        with pytest.raises(ValueError):
+            _normalize_size_arg("auto", "shards", allow_auto=False)
+
+    def test_rechunk_dataset_shard_multiple_of_chunk(self):
+        ds = xr.Dataset({"v": (("t", "x"), np.zeros((240, 200), dtype="f4"))}).chunk(
+            {"t": 24, "x": 100}
+        )
+        out = _rechunk_dataset(
+            ds, _RechunkSpec(chunks={"t": 12, "x": 50}, shards=4 * 1024 * 1024)
+        )
+        chunks = out["v"].encoding["chunks"]
+        shards = out["v"].encoding["shards"]
+        assert chunks == (12, 50)
+        assert all(s % c == 0 for s, c in zip(shards, chunks))
+
+    def test_rechunk_dataset_shard_smaller_than_chunk_disables(self):
+        ds = xr.Dataset({"v": (("t", "x"), np.zeros((240, 200), dtype="f4"))}).chunk(
+            {"t": 240, "x": 200}
+        )
+        with pytest.warns(UserWarning, match="unsharded"):
+            out = _rechunk_dataset(ds, _RechunkSpec(chunks=None, shards=8))
+        assert "shards" not in out["v"].encoding
+
+    def test_representative_source_size(
+        self, local_om2_datastore_path, intake_esm_kwargs, tmpdir
+    ):
+        builder = self._builder(
+            local_om2_datastore_path, intake_esm_kwargs, tmpdir / "s.icechunk"
+        )
+        size = _representative_source_size(builder._source_file_paths(), n=5)
+        assert isinstance(size, int) and size > 0
+
+    def test_build_with_chunk_size(
+        self, local_om2_datastore_path, intake_esm_kwargs, tmpdir
+    ):
+        store_path = tmpdir / "chunksize.icechunk"
+        builder = self._builder(local_om2_datastore_path, intake_esm_kwargs, store_path)
+        builder.rechunk(chunks="4KiB").build()
+
+        arrays = self._multidim_data_arrays(store_path)
+        assert arrays  # the store has multi-dim data variables
+        for arr in arrays.values():
+            chunk_bytes = int(np.prod(arr.chunks)) * arr.dtype.itemsize
+            full_bytes = int(np.prod(arr.shape)) * arr.dtype.itemsize
+            assert arr.shards is None
+            # dask keeps each chunk at/under the target; only arrays bigger than
+            # the target are actually split.
+            if full_bytes > 4 * 1024:
+                assert chunk_bytes <= 4 * 1024
+                assert arr.chunks != arr.shape
+
+    def test_build_with_chunk_dict(
+        self, local_om2_datastore_path, intake_esm_kwargs, tmpdir
+    ):
+        store_path = tmpdir / "chunkdict.icechunk"
+        builder = self._builder(local_om2_datastore_path, intake_esm_kwargs, store_path)
+        builder.rechunk(chunks={"time": 1}).build()
+
+        seen_time = False
+        for arr in self._multidim_data_arrays(store_path).values():
+            dims = arr.metadata.dimension_names
+            if dims and "time" in dims:
+                seen_time = True
+                assert arr.chunks[dims.index("time")] == 1
+        assert seen_time  # at least one data var has a time dimension
+
+    def test_build_with_shards_auto(
+        self, local_om2_datastore_path, intake_esm_kwargs, tmpdir
+    ):
+        store_path = tmpdir / "shardsauto.icechunk"
+        builder = self._builder(local_om2_datastore_path, intake_esm_kwargs, store_path)
+        builder.rechunk(chunks="2KiB", shards="auto").build()
+
+        sharded = [
+            a for a in self._multidim_data_arrays(store_path).values() if a.shards
+        ]
+        assert sharded  # at least one variable ended up sharded
+        for arr in sharded:
+            assert all(s % c == 0 for s, c in zip(arr.shards, arr.chunks))
 
 
 class TestIcechunkCephStoreBuilder(BuilderTests):

--- a/tests/test_source_build.py
+++ b/tests/test_source_build.py
@@ -16,6 +16,7 @@ import xarray as xr
 import zarr
 from access_nri_intake.source.builders import AccessOm2Builder
 from dotenv import load_dotenv
+from icechunk.xarray import to_icechunk
 from intake_esm.core import esm_datastore
 from obstore.store import ObjectStore, from_url
 from pandas.testing import assert_frame_equal
@@ -26,9 +27,11 @@ from intake_virtual_icechunk.source import (
     VirtualIcechunkStoreBuilder,
 )
 from intake_virtual_icechunk.source._build import (
+    _inner_chunk_shape,
     _normalize_size_arg,
     _rechunk_dataset,
     _RechunkSpec,
+    _resolve_shard_shape,
 )
 from intake_virtual_icechunk.source.utils import GroupEntry, GroupEntryError
 from intake_virtual_icechunk.utils import (
@@ -1104,10 +1107,77 @@ class TestZarrIcechunkStoreBuilder:
             _normalize_size_arg("not-a-size", "chunks", allow_auto=True)
         with pytest.raises(ValueError):
             _normalize_size_arg({"time": 0}, "chunks", allow_auto=True)
+        with pytest.raises(ValueError):
+            _normalize_size_arg(-5, "chunks", allow_auto=True)
         with pytest.raises(TypeError):
             _normalize_size_arg([1, 2], "chunks", allow_auto=True)
         with pytest.raises(ValueError):
             _normalize_size_arg("auto", "shards", allow_auto=False)
+
+    def test_inner_chunk_shape(self):
+        # numpy-backed (not dask) -> whole dimension is one chunk
+        numpy_var = xr.DataArray(np.zeros((3, 4)), dims=("a", "b"))
+        assert _inner_chunk_shape(numpy_var) == {"a": 3, "b": 4}
+        # dask-backed -> first block length per dimension
+        dask_var = numpy_var.chunk({"a": 2, "b": 4})
+        assert _inner_chunk_shape(dask_var) == {"a": 2, "b": 4}
+
+    def test_resolve_shard_shape_dict(self):
+        var = xr.DataArray(np.zeros((240, 200), dtype="f4"), dims=("t", "x"))
+        chunk_by_dim = {"t": 12, "x": 50}
+        # unlisted dims default to one chunk; listed dims kept (multiples of chunk)
+        shard = _resolve_shard_shape("v", var, chunk_by_dim, {"t": 24})
+        assert shard == {"t": 24, "x": 50}
+
+    def test_resolve_shard_shape_dict_smaller_than_chunk_disables(self):
+        var = xr.DataArray(np.zeros((240, 200), dtype="f4"), dims=("t", "x"))
+        chunk_by_dim = {"t": 12, "x": 50}
+        with pytest.warns(UserWarning, match="unsharded"):
+            assert _resolve_shard_shape("v", var, chunk_by_dim, {"t": 6}) is None
+
+    def test_rechunk_dataset_sharded_roundtrip(self, tmpdir):
+        """Inner chunk strictly smaller than shard must survive a to_icechunk write.
+
+        Regression guard: this only succeeds if the dask graph is realigned to the
+        shard shape (otherwise to_icechunk raises "would overlap multiple Dask
+        chunks") and encoding['chunks'] pins the inner chunk.
+        """
+        ds = xr.Dataset({"v": (("t", "x"), np.zeros((240, 200), dtype="f4"))}).chunk(
+            {"t": 24, "x": 100}
+        )
+        out = _rechunk_dataset(
+            ds, _RechunkSpec(chunks={"t": 12, "x": 50}, shards={"t": 24, "x": 100})
+        )
+
+        repo = icechunk.Repository.create(
+            icechunk.local_filesystem_storage(str(tmpdir / "sharded.icechunk"))
+        )
+        with repo.transaction("main", message="shard test") as store:
+            to_icechunk(out, store.session, group="g", mode="a")
+
+        arr = zarr.open_group(repo.readonly_session("main").store, mode="r")["g"]["v"]
+        assert arr.chunks == (12, 50)
+        assert arr.shards == (24, 100)
+        assert arr.chunks != arr.shards  # genuinely sub-shard chunked
+
+    def test_rechunk_dataset_chunks_auto(self):
+        # "auto" hands the shape to dask; a numpy-backed dataset becomes chunked.
+        ds = xr.Dataset({"v": (("t", "x"), np.zeros((100, 100), dtype="f4"))})
+        assert ds["v"].chunks is None
+        out = _rechunk_dataset(ds, _RechunkSpec(chunks="auto", shards=None))
+        assert out["v"].chunks is not None
+
+    def test_rechunk_dataset_skips_scalar_data_var(self):
+        # A dimensionless data variable can't be sharded and must be skipped.
+        ds = xr.Dataset(
+            {
+                "s": ((), np.float32(1.0)),
+                "v": (("t", "x"), np.zeros((48, 48), dtype="f4")),
+            }
+        ).chunk({"t": 12, "x": 12})
+        out = _rechunk_dataset(ds, _RechunkSpec(chunks=None, shards={"t": 24, "x": 24}))
+        assert "shards" not in out["s"].encoding
+        assert out["v"].encoding["shards"] == (24, 24)
 
     def test_rechunk_dataset_shard_multiple_of_chunk(self):
         ds = xr.Dataset({"v": (("t", "x"), np.zeros((240, 200), dtype="f4"))}).chunk(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,9 +45,9 @@ class TestSidecarUrl:
     def test_file_uri(self):
         # Regression: Path() on POSIX collapses file:///path → file:/path
         result = _sidecar_url("file:///tmp/demo.icechunk")
-        assert result == "file:///tmp/demo.icechunk/_intake_demo.json", (
-            f"file:// URI mangled: got {result!r}"
-        )
+        assert (
+            result == "file:///tmp/demo.icechunk/_intake_demo.json"
+        ), f"file:// URI mangled: got {result!r}"
 
     def test_file_uri_trailing_slash(self):
         result = _sidecar_url("file:///tmp/demo.icechunk/")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from intake_virtual_icechunk.utils import (
     _filter_config_args,
     _intake_cat_filename,
     _path_to_url,
+    _representative_source_size,
     _resolve_store,
     _resolve_vcc_store,
     _sidecar_url,
@@ -44,9 +45,9 @@ class TestSidecarUrl:
     def test_file_uri(self):
         # Regression: Path() on POSIX collapses file:///path → file:/path
         result = _sidecar_url("file:///tmp/demo.icechunk")
-        assert (
-            result == "file:///tmp/demo.icechunk/_intake_demo.json"
-        ), f"file:// URI mangled: got {result!r}"
+        assert result == "file:///tmp/demo.icechunk/_intake_demo.json", (
+            f"file:// URI mangled: got {result!r}"
+        )
 
     def test_file_uri_trailing_slash(self):
         result = _sidecar_url("file:///tmp/demo.icechunk/")
@@ -203,3 +204,25 @@ class TestResolveStore:
     def test_azure_raises_not_implemented(self):
         with pytest.raises(NotImplementedError, match="Azure"):
             _resolve_store("az://my-container/", {})
+
+
+class TestRepresentativeSourceSize:
+    def test_returns_median_size(self, tmp_path):
+        # Three local files of known size; median bytes is returned.
+        paths = []
+        for i, size in enumerate((10, 100, 1000)):
+            p = tmp_path / f"f{i}.bin"
+            p.write_bytes(b"\0" * size)
+            paths.append(str(p))
+        assert _representative_source_size(paths) == 100
+
+    def test_empty_paths_raises(self):
+        with pytest.raises(ObjectStoreError, match="No source file paths"):
+            _representative_source_size([])
+
+    def test_all_heads_fail_raises(self, tmp_path):
+        # A path that does not exist: every HEAD fails and is skipped, leaving
+        # no sizes to summarise.
+        missing = str(tmp_path / "does_not_exist.nc")
+        with pytest.raises(ObjectStoreError, match="Could not HEAD"):
+            _representative_source_size([missing])


### PR DESCRIPTION
Add an opt-in `IcechunkStoreBuilder.rechunk(chunks=..., shards=...)` configuring on-disk zarr chunk shapes and optional zarr v3 sharding, applied between open_mfdataset and to_icechunk in _write_entry. If never called, build behaviour is unchanged. Returns self for chaining.

Each axis accepts the dask/xarray-style polymorphic value: None (native / off), "auto", a byte size (parsed by dask.utils.parse_bytes), or a {dim: length} mapping. Chunk shape calculation is delegated to dask; shard shapes are computed per data variable and snapped to an integer multiple of the chunk. shards="auto" targets the median on-disk size of the first ~10 source files (async obstore HEAD via _representative_source_size). A shard smaller than one chunk disables sharding for that variable with a warning.

Tested: unit coverage for arg normalisation/validation, shard multiple-of- chunk, and shard<chunk disabling; integration round-trips (chunk size, chunk dict, shards=auto) building a real store and reopening to assert on-disk chunks/shards.